### PR TITLE
fix MPI_Initialized

### DIFF
--- a/src/mpi/init/fginit.c
+++ b/src/mpi/init/fginit.c
@@ -102,7 +102,6 @@ void FG_Spawn_threads(FG_WrapperProcessPtr_t WrapProcessPtr, FWraparg_t* FG_Wrap
             runlist_init();
         }
     FGP_inits++; /* This is Main co */
-    FGP_init_state = FGP_ALL_POST_INIT;
 
     sched_init_progress_thread();
 
@@ -170,6 +169,7 @@ int FGmpiexec( int *argc, char ***argv, LookupMapPtr_t lookupFuncPtr )
         FG_Spawn_threads(WrapProcessPtr, FG_Wrapargs, numspawn, argc, argv);
     }
 
+    FGP_init_state = FGP_ALL_POST_INIT;
     (*FG_MPI_Main_processPtr)(*argc, *argv);
 
  fn_exit:

--- a/src/mpi/init/init.c
+++ b/src/mpi/init/init.c
@@ -167,14 +167,13 @@ int MPI_Init( int *argc, char ***argv )
         {
             if (OPA_load_int(&MPIR_Process.mpich_state) != MPICH_PRE_INIT) {
 #if defined(FINEGRAIN_MPI)
-                if(1 == IS_SPAWNER){
-                    MPIU_Assert( (FGP_POST_INIT == FGP_init_state) ||
-                                 (FGP_ALL_POST_INIT == FGP_init_state) );
+                if((1 == IS_SPAWNER) && (FGP_ALL_POST_INIT == FGP_init_state)) {
                     IS_SPAWNER = 2; /* IS_SPAWNER equal to 2 means this is the
                                        expected (silent) MPI_Init()and
                                        it has now been seen. */
                     return (mpi_errno);
-                } else if ((2 == IS_SPAWNER) || (0 == IS_SPAWNER)){
+                } else if ( ((2 == IS_SPAWNER) || (0 == IS_SPAWNER)) ||
+                            ((1 == IS_SPAWNER) && (FGP_POST_INIT == FGP_init_state)) ){
                     MPL_internal_error_printf("WARNING! Application rank=%d is calling MPI_Init() again after initialization!\n", my_fgrank);
                     mpi_errno = MPIR_Err_create_code( MPI_SUCCESS, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__, MPI_ERR_OTHER,
 						  "**inittwice", NULL );

--- a/src/mpi/init/initialized.c
+++ b/src/mpi/init/initialized.c
@@ -70,11 +70,9 @@ int MPI_Initialized( int *flag )
     /* ... body of routine ...  */
 
 #if defined(FINEGRAIN_MPI)
-    *flag = (FGP_init_state == FGP_ALL_POST_INIT
-             || (FGP_init_state == FGP_POST_INIT
-                 && 0 != CO_CURRENT->statevars))
-            && (IS_SPAWNER!=1);
-    
+    *flag = (0 != CO_CURRENT->statevars)
+             && (((FGP_init_state == FGP_ALL_POST_INIT) && (IS_SPAWNER != 1))
+                   || (FGP_init_state == FGP_POST_INIT));
 #else
     *flag = (OPA_load_int(&MPIR_Process.mpich_state) >= MPICH_POST_INIT);
 #endif

--- a/src/mpi/init/initialized.c
+++ b/src/mpi/init/initialized.c
@@ -70,7 +70,11 @@ int MPI_Initialized( int *flag )
     /* ... body of routine ...  */
 
 #if defined(FINEGRAIN_MPI)
-    *flag = (FGP_init_state == FGP_ALL_POST_INIT);
+    *flag = (FGP_init_state == FGP_ALL_POST_INIT
+             || (FGP_init_state == FGP_POST_INIT
+                 && 0 != CO_CURRENT->statevars))
+            && (IS_SPAWNER!=1);
+    
 #else
     *flag = (OPA_load_int(&MPIR_Process.mpich_state) >= MPICH_POST_INIT);
 #endif


### PR DESCRIPTION
Several programs/libraries depend on the fact that MPI_Initialized()
will return 0 before you call MPI_Init() and 1 after you do. The logic
is somewhat complicated, because MPI will be initialized by FG-MPI
before the user calls MPI_Init() for every rank. Just checking for
FGP_ALL_POST_INIT won't work, because this will never be reached if -nfg
is 1.

This is tested to work (see 
[hello2.cc.txt](https://github.com/humairakamal/fgmpi/files/148679/hello2.cc.txt for an example). Is there a FG-MPI specific testsuite somewhere in this repository?
